### PR TITLE
formatter class created, create policy fixed

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,29 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+
+        {
+            "name": "Python: Current File",
+            "type": "python",
+            "request": "launch",
+            "program": "${file}",
+            "console": "integratedTerminal"
+        },
+        {
+            "name": "Launch migra",
+            "type": "python",
+            "request": "launch",
+            "program": "command.py",
+            "args": ["--with-privileges",
+                "postgresql://postgres:bwm8hk4KduBbaNeh01GxemvV9xUB1ilT6YyLboxlDoP4FY44Gl@dev-db-rds-cluster.cluster-cahcncaz1toj.us-west-2.rds.amazonaws.com:5432/core",
+                "postgresql://postgres:@localhost:5432/latch-console-dev",
+                "--unsafe"
+            ],
+            "console": "integratedTerminal",
+            "cwd": "${workspaceFolder}/migra"
+        }
+    ]
+}

--- a/migra/changes.py
+++ b/migra/changes.py
@@ -2,11 +2,16 @@ from __future__ import unicode_literals
 
 from collections import OrderedDict as od
 from functools import partial
+from venv import create
 
 import schemainspect
 
-from .statements import Statements
-from .util import differences
+try:
+    from .statements import Statements
+    from .util import differences
+except ImportError:
+    from statements import Statements
+    from util import differences
 
 THINGS = [
     "schemas",

--- a/migra/command.py
+++ b/migra/command.py
@@ -6,8 +6,12 @@ from contextlib import contextmanager
 
 from sqlbag import S
 
-from .migra import Migration
-from .statements import UnsafeMigrationException
+try:
+    from .migra import Migration
+    from .statements import UnsafeMigrationException
+except ImportError:
+    from migra import Migration
+    from statements import UnsafeMigrationException
 
 
 @contextmanager
@@ -107,3 +111,6 @@ def do_command():  # pragma: no cover
     args = parse_args(sys.argv[1:])
     status = run(args)
     sys.exit(status)
+
+if __name__ == '__main__':
+    do_command()

--- a/migra/formatter.py
+++ b/migra/formatter.py
@@ -1,0 +1,17 @@
+import re
+
+class Formatter:
+
+    def __init__(self, eager_parens: bool=True) -> None:
+        # add other format wide configs
+        self.eager_parens = eager_parens
+
+
+    def create_policy(self, all_changes):
+        if self.eager_parens:
+            # only fails on check true params, so hard coding is ok
+            for i, change in enumerate(all_changes):
+                all_changes[i] = re.sub(r'with\s+check\s+true', 'with check (true)', change)
+        return all_changes
+
+    

--- a/migra/migra.py
+++ b/migra/migra.py
@@ -3,8 +3,14 @@ from __future__ import unicode_literals
 from schemainspect import DBInspector, get_inspector
 from sqlbag import raw_execute
 
-from .changes import Changes
-from .statements import Statements
+try:
+    from .changes import Changes
+    from .formatter import Formatter
+    from .statements import Statements
+except ImportError:
+    from changes import Changes
+    from formatter import Formatter
+    from statements import Statements
 
 
 class Migration(object):
@@ -75,6 +81,8 @@ class Migration(object):
             self.add(self.changes.extensions(drops_only=True))
 
     def add_all_changes(self, privileges=False):
+        formatter = Formatter()
+
         self.add(self.changes.schemas(creations_only=True))
 
         self.add(self.changes.extensions(creations_only=True, modifications=False))
@@ -108,7 +116,7 @@ class Migration(object):
 
         if privileges:
             self.add(self.changes.privileges(creations_only=True))
-        self.add(self.changes.rlspolicies(creations_only=True))
+        self.add(formatter.create_policy(self.changes.rlspolicies()))
         self.add(self.changes.triggers(creations_only=True))
         self.add(self.changes.collations(drops_only=True))
         self.add(self.changes.schemas(drops_only=True))


### PR DESCRIPTION
For documentation on how to replicate the process view the [wiki](https://github.com/latchbio/migra/wiki/Fixing-Format-Errors)

### Highlights

Formatter Object created. For any future format checks add correction methods in this *singleton* object. Then apply them to the offending type of change, found in the [`Migration#add_all_changes`](https://github.com/latchbio/migra/blob/01acaf2edac85f2a9329169159ad610ab1fa66be/migra/migra.py#L77) method and encapsulate it by first calling the offending partial. For further detail, view the diff

Some convenience changes include:

- convenience import functions and runners for ease of debugging
- configurations for VSCode debug for a consistent dev experience

resolves #3